### PR TITLE
add new sonic pi path

### DIFF
--- a/sonic-pi-tool.py
+++ b/sonic-pi-tool.py
@@ -48,7 +48,8 @@ class Installation:
                      '/opt/sonic-pi/app',
                      '/usr/bin/sonic-pi-*',
                      '/usr/bin/sonic-pi',
-                     '/usr/lib/sonic-pi')
+                     '/usr/lib/sonic-pi',
+                     '/usr/lib/sonic-pi/app')
     ruby_paths = ['server/native/ruby/bin/ruby',
                   'server/native/ruby/bin/ruby.exe']
     server_paths = ['server/ruby/bin/sonic-pi-server.rb',


### PR DESCRIPTION
The Sonic Pi server path on version 3.2.2, on Debian, has changed path to /usr/lib/sonic-pi/app/. This PR adds that path to it.